### PR TITLE
late binding for encryption function

### DIFF
--- a/encrypt_content/encrypt_content.py
+++ b/encrypt_content/encrypt_content.py
@@ -45,14 +45,9 @@ def encrypt(password, plaintext):
 
 def protect_content(instance):
     if 'password' in instance.metadata:
-        # encrypt content
-        iv_b64, ciphertext_b64, padding_char = encrypt(instance.metadata['password'], 
-                                                       instance.content.encode('utf8'))
-        
         # set new attributes for use in templates
         setattr(instance, 'protected', True)
-        setattr(instance, 'encrypted_content', '%s;%s;%s' % (iv_b64, ciphertext_b64, 
-                                                             padding_char))
+        setattr(instance, 'encrypt', lambda content:"%s;%s;%s"%encrypt(instance.metadata['password'], content.encode('utf8')))
 
 
 def register():

--- a/theme/templates/encrypt-content-content.html
+++ b/theme/templates/encrypt-content-content.html
@@ -1,5 +1,5 @@
 {% if article.protected %}
-<div id="encrypted-content" style="display:none">{{ article.encrypted_content }}</div>
+<div id="encrypted-content" style="display:none">{{ article.encrypt(article.content) }}</div>
 <div id="decrypted-content">
     <h4><i>This content is encrypted.</i></h4>
 </div>


### PR DESCRIPTION
Some important things happen right after the content_object_init signal, e.g. the |filename| special function to resolve urls is applied to the content. So I want to encrypt the page as late as possible.

This patch removes the `encrypted_content` attribute for the instance and adds an `encrypt` function instead to the instance. The template is changed in order to use the `encrypt` function. So the encryption actually takes place when the content is rendered by the template.
