### PR TITLE
Modified to run on Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This plugin allows you to have password protected articles and pages in [Pelican
 content is encrypted with AES-256 in Python using [PyCrypto](https://www.dlitz.net/software/pycrypto/), and 
 decrypted in the browser with [Crypto-JS](https://code.google.com/p/crypto-js/). 
 
+This particular version will work with Python 3, but probably breaks competability with Python 2.
+
 ####Requirements
 
 - Pelican 3.6+
@@ -58,9 +60,9 @@ ex.
     Password: correcthorsebatterystaple
 
 
-####Python 3 Support
+####Now with Python 3 Support
 
-I haven't tested this with Python 3 because I'm lazy, but the Python portion of the plugin is not long or complicated. If you happen to notice any problems with Python 3 and fix them, please submit a pull request.
+As an exercise in Python and git, I've maanged to get this awesome plugin by mindcruzer to work on Python 3.4.3. Most changes were dealing with Unicode encoding-decoding. I couldn't get the tuple of byte elements to decode within the structure, so I went for the ugly way and extracted each element.
 
 ####Earlier versions of Pelican
 

--- a/encrypt_content/encrypt_content.py
+++ b/encrypt_content/encrypt_content.py
@@ -48,13 +48,13 @@ def _encrypt_text_aes(text, password):
     
     # key must be 32 bytes for AES-256
     key = hashlib.md5()
-    key.update(password)
+    key.update(password.encode('utf-8'))
     cipher = AES.new(key.digest(), AES.MODE_CBC, iv)
 
     # plaintext must be padded to be a multiple of BLOCK_SIZE
-    plaintext_padded = text + (BLOCK_SIZE - len(text) % BLOCK_SIZE) * PADDING_CHAR
+    plaintext_padded = text + ((BLOCK_SIZE - len(text) % BLOCK_SIZE) * PADDING_CHAR).encode('utf-8')
     ciphertext = cipher.encrypt(plaintext_padded)
-    
+
     return (
         base64.b64encode(iv),
         base64.b64encode(ciphertext),
@@ -67,9 +67,13 @@ def _encrypt_content(content):
     Replaces page or article content with decrypt form.
     """
     ciphertext_bundle = _encrypt_text_aes(content._content.encode('utf8'), content.password)
+    a = ciphertext_bundle[0].decode('utf-8')
+    b = ciphertext_bundle[1].decode('utf-8')
+    c = ciphertext_bundle[2]
+
     decrypt_form = Template(DECRYPT_FORM_TPL).render({
         'summary': settings['summary'],
-        'ciphertext_bundle': ';'.join(ciphertext_bundle),
+        'ciphertext_bundle': ';'.join([a,b,c]),
         'js_libraries': JS_LIBRARIES
     })
 


### PR DESCRIPTION
Hi there,

I've made modification so pelican-encrypt-content can now run on Python 3. However, I haven't tested it on Python 2 so I'm not certain about backwards compatibility. As you can see, most problems were simply dealing with Unicode encoding/decoding syntax.

This is my first foray into sending a pull request, I hope I'm doing it right.
Thanks for this very useful plugin.
