### PR TITLE
Fixing import for usage in getpelican/pelican-plugins repo

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .encrypt_content import *


### PR DESCRIPTION
Avoid this error:

    AttributeError: module 'pelican-encrypt-content' has no attribute 'register'