### PR TITLE
Allow passing URL by search query and add option to hide query once used

### DIFF
--- a/pelican/plugins/encrypt_content/decrypt-form.tpl.html
+++ b/pelican/plugins/encrypt_content/decrypt-form.tpl.html
@@ -82,12 +82,25 @@
                     // ¯\_(ツ)_/¯
                     password_input.value = '';
                 }
-                event.preventDefault();
+                if (event) event.preventDefault();
                 return false;
             }
-            
+
             decrypt_btn.addEventListener('click', decrypt_document);
             decrypt_form.addEventListener('submit', decrypt_document);
+
+            var search_params = (new URLSearchParams(window.location.search));
+            var search_pw = search_params.get("pw")
+            if (search_pw != null) {
+                password_input.value = search_pw
+                decrypt_btn.click()
+
+                {% if consume_search %}
+                search_params.delete("pw")
+                window.history.replaceState(null, null, search_params.toString() || "?");
+                {% endif %}
+            }
+
         });
     })();
 </script>

--- a/pelican/plugins/encrypt_content/encrypt_content.py
+++ b/pelican/plugins/encrypt_content/encrypt_content.py
@@ -34,7 +34,8 @@ with pelican_open(DECRYPT_FORM_TPL_PATH) as template:
 
 settings = {
     'title_prefix': '',
-    'summary': ''
+    'summary': '',
+    'consume_search': False
 }
 
 
@@ -83,7 +84,8 @@ def encrypt_content(content):
         # this benign decoding is necessary before writing to the template, 
         # otherwise the output string will be wrapped with b''
         'ciphertext_bundle': b';'.join(ciphertext_bundle).decode('ascii'),
-        'js_libraries': JS_LIBRARIES
+        'js_libraries': JS_LIBRARIES,
+        'consume_search': settings['consume_search']
     })
 
     content._content = decrypt_form


### PR DESCRIPTION
Okay, this deserves some explanation

This PR adds the ability to manually pass a password in via the url query search string.

So, if your article sits at `http://blog.mysite/drafts/secretarticle.html`, and the encrypted password is ``http://blog.mysite/drafts/secretarticle.html`, you can navigate to `http://blog.mysite/drafts/secretarticle.html?pw=mysecret` and the page will automatically try to submit that password in the form. 

There is also an option provided to "consume" that data after navigation to slightly obfuscate the password from casual copying, so `http://blog.mysite/drafts/secretarticle.html?pw=mysecret` would silently redirect to `http://blog.mysite/drafts/secretarticle.html?` if the `consume_search` option is set to True.

Marking this as a draft as features are not strictly finalized and documentation is not yet written, pending review